### PR TITLE
working Windows makevars for OpenMP

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,0 +1,6 @@
+# From https://github.com/eddelbuettel/winsorize/blob/master/src/Makevars.win
+## This assume that we can call Rscript to ask Rcpp about its locations
+## Use the R_HOME indirection to support installations of multiple R version
+#PKG_LIBS = $(shell $(R_HOME)/bin/Rscript.exe -e "Rcpp:::LdFlags()") $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
+PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
+PKG_LIBS = $(shell $(R_HOME)/bin/Rscript.exe -e "Rcpp:::LdFlags()") $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,5 @@
 # From https://github.com/eddelbuettel/winsorize/blob/master/src/Makevars.win
 ## This assume that we can call Rscript to ask Rcpp about its locations
 ## Use the R_HOME indirection to support installations of multiple R version
-#PKG_LIBS = $(shell $(R_HOME)/bin/Rscript.exe -e "Rcpp:::LdFlags()") $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
 PKG_LIBS = $(shell $(R_HOME)/bin/Rscript.exe -e "Rcpp:::LdFlags()") $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS)


### PR DESCRIPTION
These makevars (courtesy of winsorize package) worked for me on Windows 8.1, R 3.5, and RTools 3.5.