### PR TITLE
Faster st connect

### DIFF
--- a/R/st_connect.R
+++ b/R/st_connect.R
@@ -3,7 +3,7 @@
 #' @param x Object of class \code{sf} or \code{sfc}
 #' @param y Object of class \code{sf} or \code{sfc}
 #' @param ids A sparse list representation of features to connect such as returned by function \code{\link{st_nn}}. If \code{NULL} the function automatically calculates \code{ids} using \code{\link{st_nn}}
-#' @param dist Sampling distance interval for generating outline points to choose from. Only relevant when at lear one of \code{x} or \code{y} is a line or polygon layer. Should be given in CRS units for projected layers, or in meters for layers in lon/lat
+#' @param dist Sampling distance interval for generating outline points to choose from. Only relevant when at least one of \code{x} or \code{y} is a line or polygon layer. Should be given in CRS units for projected layers, or in meters for layers in lon/lat
 #' @param progress Display progress bar? (default \code{TRUE})
 #' @param ... Other arguments passed to \code{st_nn} when calculating \code{ids}, such as \code{k} and \code{maxdist}
 #'

--- a/tests/testthat/test_st_connect.R
+++ b/tests/testthat/test_st_connect.R
@@ -1,0 +1,72 @@
+library(nngeo)
+
+context("st_connect")
+
+test_that("'st_connect' points", {
+
+  city_geoms <- st_geometry(cities)
+  town_geoms <- st_geometry(towns)
+
+  lines <- st_connect(cities, towns, k = 2)
+
+  expect_equivalent(
+    lines,
+    c(
+      st_cast(
+        st_combine(
+          c(
+            city_geoms[1],
+            town_geoms[29]
+          )
+        ),
+        "LINESTRING"
+      ),
+      st_cast(
+        st_combine(
+          c(
+            city_geoms[1],
+            town_geoms[40]
+          )
+        ),
+        "LINESTRING"
+      ),
+      st_cast(
+        st_combine(
+          c(
+            city_geoms[2],
+            town_geoms[18]
+          )
+        ),
+        "LINESTRING"
+      ),
+      st_cast(
+        st_combine(
+          c(
+            city_geoms[2],
+            town_geoms[19]
+          )
+        ),
+        "LINESTRING"
+      ),
+      st_cast(
+        st_combine(
+          c(
+            city_geoms[3],
+            town_geoms[69]
+          )
+        ),
+        "LINESTRING"
+      ),
+      st_cast(
+        st_combine(
+          c(
+            city_geoms[3],
+            town_geoms[80]
+          )
+        ),
+        "LINESTRING"
+      )
+    )
+  )
+
+})


### PR DESCRIPTION
This avoids updating the final line layer from within a for loop. On my machine it is about 10x faster (3 seconds vs 30 seconds to connect 1000 pairs of points).