### PR TITLE
Adding argument max_area to st_remove_holes()

### DIFF
--- a/man/st_remove_holes.Rd
+++ b/man/st_remove_holes.Rd
@@ -4,10 +4,13 @@
 \alias{st_remove_holes}
 \title{Remove polygon holes}
 \usage{
-st_remove_holes(x)
+st_remove_holes(x, max_area = 0)
 }
 \arguments{
 \item{x}{Object of class \code{sf}, \code{sfc} or \code{sfg}, of type \code{"POLYGON"} or \code{"MULTIPOLYGON"}}
+
+\item{max_area}{Numeric: maximum area of holes to be removed (in the unit
+of `x`). Default value (0) causes removing all holes.}
 }
 \value{
 Object of same class as \code{x}, with holes removed
@@ -66,6 +69,14 @@ par(opar)
 x = st_sfc(pol, mpol * 0.75 + c(3.5, 2))
 x = st_sf(geom = x, data.frame(id = 1:length(x)))
 result = st_remove_holes(x)
+result
+plot(x, main = "Before")
+plot(result, main = "After")
+
+# Example with 'sf' using argument 'max_area'
+x = st_sfc(pol, mpol * 0.75 + c(3.5, 2))
+x = st_sf(geom = x, data.frame(id = 1:length(x)))
+result = st_remove_holes(x, max_area = 0.4)
 result
 plot(x, main = "Before")
 plot(result, main = "After")


### PR DESCRIPTION
Hi, thank you for providing this package.
I modified function `st_remove_holes()` adding an argument `max_area`, which allows setting a maximum area for holes to be removed (holes whose area is higher than `max_area` are kept).
Moreover, using `st_polygon(geom[i][[1]][1])` instead than `st_multipolygon(lapply(tmp[j], function(p) p[1]))` allows maintaining the original class of `sf` records (POLYGON or MULTIPOLYGON) instead than converting all to MULTIPOLYGON (see output differences in the last example).
I made these changes for my personal use (I needed a function to delete only small holes); feel free to accept this PR if you think it could be useful.