### PR TITLE
Adjust for st_area calculations on lat/lon data

### DIFF
--- a/R/st_remove_holes.R
+++ b/R/st_remove_holes.R
@@ -94,6 +94,7 @@ st_remove_holes = function(x, max_area = 0) {
       if(length(geom[i][[1]]) > 1){
         if (max_area > 0) {
           holes = lapply(geom[i][[1]], function(x) {st_polygon(list(x))})[-1]
+          holes = lapply(holes, function(h) st_sfc(h, crs = st_crs(x)))
           areas = c(Inf,sapply(holes, st_area))
           geom[i] = st_polygon(geom[i][[1]][which(areas > max_area)])
         } else {
@@ -107,6 +108,7 @@ st_remove_holes = function(x, max_area = 0) {
         if(length(tmp[j][[1]]) > 1){
           if (max_area > 0) {
             holes = lapply(tmp[j][[1]], function(x) {st_polygon(list(x))})[-1]
+            holes = lapply(holes, function(h) st_sfc(h, crs = st_crs(x)))
             areas = c(Inf,sapply(holes, st_area))
             tmp[j] = st_polygon(tmp[j][[1]][which(areas > max_area)])
           } else {


### PR DESCRIPTION
Hi, 
Just wondering if nngeo::st_remove_holes could be adjusted so that, when polygons are in lat/lon geographic coordinates, lwgeom::st_geod_area is used automatically instead of sf::st_area to compute the holes' areas.
Thanks!