### PR TITLE
Fix typo about sfheaders::sf_remove_holes

### DIFF
--- a/R/st_remove_holes.R
+++ b/R/st_remove_holes.R
@@ -9,9 +9,8 @@
 #' \url{https://stackoverflow.com/questions/52654701/removing-holes-from-polygons-in-r-sf}
 #' @note
 #'
-#' See function \code{sfheaders::st_remove_holes} for highly-optimized faster alternative:
-#'
-#' \url{https://github.com/dcooley/sfheaders}
+#' See function \code{\link[sfheaders:sf_remove_holes]{sfheaders::sf_remove_holes}} for a highly-optimized faster alternative 
+#' if you don't need the argument \code{max_area}: \url{https://github.com/dcooley/sfheaders}
 #'
 #' @export
 #'

--- a/man/st_remove_holes.Rd
+++ b/man/st_remove_holes.Rd
@@ -18,9 +18,8 @@ Object of same class as \code{x}, with holes removed
 The function removes all polygon holes and return the modified layer
 }
 \note{
-See function \code{sfheaders::st_remove_holes} for highly-optimized faster alternative:
-
-\url{https://github.com/dcooley/sfheaders}
+See function \code{\link[sfheaders:sf_remove_holes]{sfheaders::sf_remove_holes}} for a highly-optimized faster alternative 
+if you don't need the argument \code{max_area}: \url{https://github.com/dcooley/sfheaders}
 }
 \examples{
 opar = par(mfrow = c(1, 2))


### PR DESCRIPTION

Just fixing a typo about sfheaders::sf_remove_holes, then at the same time getting more formal link, and adding text on max_area not supported by sfheaders